### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -5,18 +5,18 @@
 #######################################
 # Classes (KEYWORD1)
 #######################################
-SDCore  KEYWORD1
+SDCore	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
-begin   KEYWORD2
-end     KEYWORD2
+begin	KEYWORD2
+end	KEYWORD2
 read	KEYWORD2
 write	KEYWORD2
 
 ######################################
 # Constants (LITERAL1)
 #######################################
-SDCORE_CUSTOM_DDRB LITERAL1
-SDCORE_CUSTOM_SS   LITERAL1
+SDCORE_CUSTOM_DDRB	LITERAL1
+SDCORE_CUSTOM_SS	LITERAL1


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab, the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords